### PR TITLE
Server freeze fix

### DIFF
--- a/PDrive/CopyGameFiles.bat
+++ b/PDrive/CopyGameFiles.bat
@@ -30,7 +30,8 @@ xcopy "%PathDayZServer%\*.dll" "%PathGame%\" /D /Y /F
 xcopy "%PathDayZServer%\dayzsetting.xml" "%PathGame%\" /D /Y /F
 xcopy "%PathDayZServer%\serverDZ.cfg" "%PathGame%\" /D /Y  /F
 xcopy "%PathDayZServer%\dayz.gproj" "%PathGame%\" /D /Y  /F
-xcopy "%PathDayZServer%\mpmissions" "%PathGame%\Addons" /D /Y /I /F
+xcopy "%PathDayZServer%\mpmissions" "%PathGame%\mpmissions" /D /Y /I /F /E
+xcopy "%PathDayZServer%\BattlEye" "%PathGame%\BattlEye" /D /Y /I /F /E
 xcopy "%PathDayZServer%\Keys" "%PathGame%\Keys" /D /Y /I /F
 
 REM "==================================================="


### PR DESCRIPTION
After installation of the tools, the server (and, in fact, also client) were "freezed", not giving any helpful error, as explained in #1 

This was due to the lack of the `mpmissions` and` BattlEye` directories copied from the server and client files. Now the `CopyGameFiles.bat` process will take care of it.